### PR TITLE
Use Default for initializing the Default Fields

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -2,7 +2,7 @@ use super::interconnect;
 
 const NUM_GPR: usize = 32;
 
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct Cpu {
     reg_gpr: [u64; NUM_GPR],
     reg_fpr: [f64; NUM_GPR],
@@ -24,24 +24,7 @@ pub struct Cpu {
 
 impl Cpu {
     pub fn new(interconnect: interconnect::Interconnect) -> Cpu {
-        Cpu {
-            reg_gpr: [0; NUM_GPR],
-            reg_fpr: [0.0; NUM_GPR],
-
-            reg_pc: 0,
-
-            reg_hi: 0,
-            reg_lo: 0,
-
-            reg_llbit: false,
-
-            reg_fcr0: 0,
-            reg_fcr31: 0,
-
-            cp0: Cp0::default(),
-
-            interconnect: interconnect
-        }
+        Cpu { interconnect: interconnect, ..Default::default() }
     }
 
     pub fn power_on_reset(&mut self) {

--- a/src/interconnect.rs
+++ b/src/interconnect.rs
@@ -7,16 +7,21 @@ const RAM_SIZE: usize = 4 * 1024 * 1024;
 pub struct Interconnect {
     pif_rom: Vec<u8>,
 
-    ram: Vec<u16>
+    ram: Box<[u16]>,
+}
+
+impl Default for Interconnect {
+    fn default() -> Self {
+        Interconnect {
+            pif_rom: Vec::new(),
+            ram: vec![0; RAM_SIZE].into_boxed_slice(),
+        }
+    }
 }
 
 impl Interconnect {
     pub fn new(pif_rom: Vec<u8>) -> Interconnect {
-        Interconnect {
-            pif_rom: pif_rom,
-
-            ram: vec![0; RAM_SIZE]
-        }
+        Interconnect { pif_rom: pif_rom, ..Default::default() }
     }
 
     pub fn read_word(&self, addr: u32) -> u32 {


### PR DESCRIPTION
It's possible to use a combination of Default and a normal Initializer to keep the default fields while still manually specifying the values of some fields.
