### PR TITLE
Make module imports nicer with "pub use"

### DIFF
--- a/src/cpu/cp0/mod.rs
+++ b/src/cpu/cp0/mod.rs
@@ -1,3 +1,5 @@
-pub mod cp0;
+mod cp0;
 mod reg_config;
 mod reg_status;
+
+pub use self::cp0::Cp0;

--- a/src/cpu/cpu.rs
+++ b/src/cpu/cpu.rs
@@ -1,5 +1,5 @@
 use super::super::interconnect;
-use super::cp0::cp0;
+use super::cp0;
 
 const NUM_GPR: usize = 32;
 

--- a/src/cpu/mod.rs
+++ b/src/cpu/mod.rs
@@ -1,2 +1,4 @@
-pub mod cpu;
+mod cpu;
 mod cp0;
+
+pub use self::cpu::Cpu;

--- a/src/n64.rs
+++ b/src/n64.rs
@@ -1,4 +1,4 @@
-use super::cpu::cpu;
+use super::cpu;
 use super::interconnect;
 
 #[derive(Debug)]


### PR DESCRIPTION
This allows you not to export the whole cpu::cpu and cp0::cp0 submodule.
