### PR TITLE
Implemented pretty printing for the CPU general purpose and floating point registers

### DIFF
--- a/src/cpu/cpu.rs
+++ b/src/cpu/cpu.rs
@@ -66,8 +66,8 @@ impl fmt::Debug for Cpu {
             reg_hi: {:#018X}\n\
             reg_lo: {:#018X}\n\
             reg_llbit: {}\n\
-            reg_fcr0:  {:#018X}\n\
-            reg_fcr31: {:#018X}\n\
+            reg_fcr0:  {:#010X}\n\
+            reg_fcr31: {:#010X}\n\
             ", 
             self.reg_pc, 
             self.reg_hi, 

--- a/src/cpu/cpu.rs
+++ b/src/cpu/cpu.rs
@@ -1,9 +1,10 @@
 use super::super::interconnect;
 use super::cp0::cp0;
 
+use std::fmt;
+
 const NUM_GPR: usize = 32;
 
-#[derive(Debug)]
 pub struct Cpu {
     reg_gpr: [u64; NUM_GPR],
     reg_fpr: [f64; NUM_GPR],
@@ -21,6 +22,64 @@ pub struct Cpu {
     cp0: cp0::Cp0,
 
     interconnect: interconnect::Interconnect
+}
+
+impl fmt::Debug for Cpu {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        const REGS_PER_LINE: usize = 2;
+        const REG_NAMES: [&'static str; NUM_GPR] = [
+        "r0", "at", "v0", "v1", "a0", "a1", "a2", "a3",
+        "t0", "t1", "t2", "t3", "t4", "t5", "t6", "t7",
+        "s0", "s1", "s2", "s3", "s4", "s5", "s6", "s7",
+        "t8", "t9", "k0", "k1", "gp", "sp", "s8", "ra",
+        ];
+        
+        try!(write!(f,"\nCPU General Purpose Registers:"));
+        for reg_num in 0..NUM_GPR {
+            if (reg_num % REGS_PER_LINE) == 0 {
+                try!(writeln!(f,""));
+            }
+            try!(write!(f, 
+                "{reg_name}/gpr{num:02}: {value:#018X} ",
+                num = reg_num,
+                reg_name = REG_NAMES[reg_num],
+                value = self.reg_gpr[reg_num],
+            ));
+        }
+        
+        try!(write!(f,"\n\nCPU Floating Point Registers:"));    
+        for reg_num in 0..NUM_GPR {
+            if (reg_num % REGS_PER_LINE) == 0 {
+                try!(writeln!(f,""));
+            }
+            try!(write!(f, 
+                "fpr{num:02}: {value:21} ",
+                num = reg_num,
+                value = self.reg_fpr[reg_num],)
+            );
+        }
+        
+        try!(writeln!(f,"\n\nCPU Special Registers:"));
+        try!(writeln!(f, 
+            "\
+            reg_pc: {:#018X}\n\
+            reg_hi: {:#018X}\n\
+            reg_lo: {:#018X}\n\
+            reg_llbit: {}\n\
+            reg_fcr0:  {:#018X}\n\
+            reg_fcr31: {:#018X}\n\
+            ", 
+            self.reg_pc, 
+            self.reg_hi, 
+            self.reg_lo, 
+            self.reg_llbit,
+            self.reg_fcr0,
+            self.reg_fcr31
+        ));
+
+        try!(writeln!(f, "{:#?}", self.cp0));
+        writeln!(f, "{:#?}", self.interconnect)
+    }
 }
 
 impl Cpu {


### PR DESCRIPTION
-Added register short names and numbers
-Register values now printed padded and in hex

I'm pretty new to Rust and the code is definitely not as compact as it could be but it appears to work isolated in the playground. Haven't tried to clone the entire repo and test it yet.

If accepted this will also require removal of the debug print in main.rs to work.
