### PR TITLE
Added Appveyor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# rustendo64 [![Build Status](https://travis-ci.org/yupferris/rustendo64.svg?branch=master)](https://travis-ci.org/yupferris/rustendo64)
+# rustendo64 
+[![Build Status](https://travis-ci.org/yupferris/rustendo64.svg?branch=master)](https://travis-ci.org/yupferris/rustendo64)
+[![Build Status](https://ci.appveyor.com/api/projects/status/_correct_hash_here?svg=true)](https://ci.appveyor.com/project/yupferris/rustendo64)
 
 Livecoding a Nintendo 64 emulator in Rust :D
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# rustendo64 
-[![Build Status](https://travis-ci.org/yupferris/rustendo64.svg?branch=master)](https://travis-ci.org/yupferris/rustendo64)
-[![Build Status](https://ci.appveyor.com/api/projects/status/owjloq84v91147nd?svg=true)](https://ci.appveyor.com/project/yupferris/rustendo64)
+# rustendo64 [![Build Status](https://travis-ci.org/yupferris/rustendo64.svg?branch=master)](https://travis-ci.org/yupferris/rustendo64) [![Build Status](https://ci.appveyor.com/api/projects/status/owjloq84v91147nd?svg=true)](https://ci.appveyor.com/project/yupferris/rustendo64)
 
 Livecoding a Nintendo 64 emulator in Rust :D
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rustendo64 
 [![Build Status](https://travis-ci.org/yupferris/rustendo64.svg?branch=master)](https://travis-ci.org/yupferris/rustendo64)
-[![Build Status](https://ci.appveyor.com/api/projects/status/_correct_hash_here?svg=true)](https://ci.appveyor.com/project/yupferris/rustendo64)
+[![Build Status](https://ci.appveyor.com/api/projects/status/owjloq84v91147nd?svg=true)](https://ci.appveyor.com/project/yupferris/rustendo64)
 
 Livecoding a Nintendo 64 emulator in Rust :D
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# rustendo64 [![Build Status](https://travis-ci.org/yupferris/rustendo64.svg?branch=master)](https://travis-ci.org/yupferris/rustendo64) [![Build Status](https://ci.appveyor.com/api/projects/status/owjloq84v91147nd?svg=true)](https://ci.appveyor.com/project/yupferris/rustendo64)
+# rustendo64 [![Build Status](https://travis-ci.org/yupferris/rustendo64.svg?branch=master)](https://travis-ci.org/yupferris/rustendo64) [![Build Status](https://ci.appveyor.com/api/projects/status/owjloq84v91147nd/branch/master?svg=true)](https://ci.appveyor.com/project/yupferris/rustendo64/branch/master)
 
 Livecoding a Nintendo 64 emulator in Rust :D
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,16 @@
+environment:
+  matrix:
+  - TARGET: x86_64-pc-windows-msvc
+  - TARGET: i686-pc-windows-msvc
+  - TARGET: i686-pc-windows-gnu
+install:
+  - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-nightly-${env:TARGET}.exe"
+  - rust-nightly-%TARGET%.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
+  - SET PATH=%PATH%;C:\Program Files (x86)\Rust\bin
+  - SET PATH=%PATH%;C:\MinGW\bin
+  - rustc -V
+  - cargo -V
+build: false
+
+test_script:
+  - cargo test --verbose

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ environment:
   - TARGET: i686-pc-windows-msvc
   - TARGET: i686-pc-windows-gnu
 install:
-  - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-nightly-${env:TARGET}.exe"
+  - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-1.6.0-${env:TARGET}.exe"
   - rust-nightly-%TARGET%.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
   - SET PATH=%PATH%;C:\Program Files (x86)\Rust\bin
   - SET PATH=%PATH%;C:\MinGW\bin

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,9 @@ install:
   - rustc -V
   - cargo -V
 build: false
+branches:
+  only:
+    - master
 
 test_script:
   - cargo test --verbose

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
   - TARGET: i686-pc-windows-gnu
 install:
   - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-1.6.0-${env:TARGET}.exe"
-  - rust-nightly-%TARGET%.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
+  - rust-1.6.0-%TARGET%.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
   - SET PATH=%PATH%;C:\Program Files (x86)\Rust\bin
   - SET PATH=%PATH%;C:\MinGW\bin
   - rustc -V


### PR DESCRIPTION
Support for Appveyor (building with Rust on Windows) I can't test this as it needs to be enabled on Appveyor for your repro (and you need to change the `_correct_hash_here` in the commit for it too look correct because I don't know what that is now.

Hopefully this will be a good start :)
