### PR TITLE
Use Clap for parsing the Command Line Arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,42 @@ name = "rustendo64"
 version = "0.1.0"
 dependencies = [
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "ansi_term"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "byteorder"
 version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "clap"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "strsim"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "vec_map"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,7 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 byteorder = "0.4.2"
+
+[dependencies.clap]
+version = "2.0.1"
+features = [ "suggestions", "color" ]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,36 @@
 extern crate byteorder;
+#[macro_use]
+extern crate clap;
 
 mod n64;
 mod cpu;
 mod interconnect;
 
-use std::env;
 use std::fs;
 use std::io::Read;
 use std::path::Path;
+use clap::{App, Arg, ArgMatches};
+
+fn get_arguments<'a>() -> ArgMatches<'a> {
+    App::new("rustendo64")
+        .version(crate_version!())
+        .author("ferris <jake@fusetools.com>")
+        .about("Livecoding a Nintendo 64 emulator in Rust :D")
+        .arg(Arg::with_name("pif")
+                 .help("Sets the PIF ROM needed for booting")
+                 .takes_value(true)
+                 .required(true))
+        .arg(Arg::with_name("rom")
+                 .help("Sets the ROM to run")
+                 .takes_value(true)
+                 .required(true))
+        .get_matches()
+}
 
 fn main() {
-    let pif_file_name = env::args().nth(1).unwrap();
-    let rom_file_name = env::args().nth(2).unwrap();
+    let arguments = get_arguments();
+    let pif_file_name = arguments.value_of("pif").unwrap();
+    let rom_file_name = arguments.value_of("rom").unwrap();
 
     let pif = read_bin(pif_file_name);
     let rom = read_bin(rom_file_name);


### PR DESCRIPTION
The Clap crate is a simple to use, efficient, and full featured library for parsing command line arguments and subcommands when writing console, or terminal applications. It even shows a useful help message and tells you which arguments you forgot to specify if you forgot some.
