### PR TITLE
Make Rsp a unit struct

### DIFF
--- a/src/rsp.rs
+++ b/src/rsp.rs
@@ -1,7 +1,5 @@
 #[derive(Default)]
-pub struct Rsp {
-    _dummy: i32
-}
+pub struct Rsp;
 
 impl Rsp {
     // TODO: Read general regs


### PR DESCRIPTION
No need for dummy data—a struct with no fields is a unit-like struct, which is I think what you tried to do onstream but forgot the syntax for.
