### PR TITLE
Use .expect instead of .unwrap_or_else

### DIFF
--- a/src/cpu/instruction.rs
+++ b/src/cpu/instruction.rs
@@ -9,8 +9,8 @@ pub struct Instruction(pub u32);
 impl Instruction {
     #[inline(always)]
     pub fn opcode(&self) -> Opcode {
-        Opcode::from_u32((self.0  >> 26) & 0b111111).unwrap_or_else(
-            || panic!("Unrecognized instruction: {:#x}", self.0))
+        Opcode::from_u32((self.0  >> 26) & 0b111111)
+            .expect(&format!("Unrecognized instruction: {:#x}", self.0))
     }
 
     #[inline(always)]


### PR DESCRIPTION
Since you're panicking anyway (and I doubt you'll do anything else, since this code path is ultimately to be made mostly redundant in favour of the illegal-instruction machinery the CPU provides) I think you can use `Option::expect` instead of `Option::unwrap_or_else` and save whatever chicanery is involved with a closure which isn't optimised away.
