### PR TITLE
Two stylistic changes

### DIFF
--- a/src/cpu/cpu.rs
+++ b/src/cpu/cpu.rs
@@ -83,8 +83,8 @@ impl Cpu {
                 self.write_reg_gpr(instr.rt(), res);
             },
             Addiu => {
-                let res = self.read_reg_gpr(instr.rs()).wrapping_add(
-                    instr.imm_sign_extended());
+                let res = self.read_reg_gpr(instr.rs())
+                    .wrapping_add(instr.imm_sign_extended());
                 self.write_reg_gpr(instr.rt(), res);
             },
             Andi => {

--- a/src/cpu/opcode.rs
+++ b/src/cpu/opcode.rs
@@ -8,7 +8,6 @@ enum_from_primitive! {
         Ori =   0b001101,
 
         Lui =   0b001111,
-
         Mtc0 =  0b010000,
 
         Beql =  0b010100,


### PR DESCRIPTION
- Rust style is to put the linebreak before the method dot
- There is no gap between 0b01111 and 0b10000 :)
