### PR TITLE
Use Default for uninitialised bits of Cpu struct

### DIFF
--- a/src/cpu/cpu.rs
+++ b/src/cpu/cpu.rs
@@ -7,6 +7,7 @@ use std::fmt;
 
 const NUM_GPR: usize = 32;
 
+#[derive(Default)]
 pub struct Cpu {
     reg_gpr: [u64; NUM_GPR],
     reg_fpr: [f64; NUM_GPR],
@@ -23,29 +24,12 @@ pub struct Cpu {
 
     cp0: cp0::Cp0,
 
-    interconnect: interconnect::Interconnect
+    interconnect: interconnect::Interconnect,
 }
 
 impl Cpu {
     pub fn new(interconnect: interconnect::Interconnect) -> Cpu {
-        Cpu {
-            reg_gpr: [0; NUM_GPR],
-            reg_fpr: [0.0; NUM_GPR],
-
-            reg_pc: 0,
-
-            reg_hi: 0,
-            reg_lo: 0,
-
-            reg_llbit: false,
-
-            reg_fcr0: 0,
-            reg_fcr31: 0,
-
-            cp0: cp0::Cp0::default(),
-
-            interconnect: interconnect
-        }
+        Cpu { interconnect: interconnect, ..Default::default() }
     }
 
     pub fn power_on_reset(&mut self) {

--- a/src/interconnect.rs
+++ b/src/interconnect.rs
@@ -44,3 +44,10 @@ impl fmt::Debug for Interconnect {
         write!(f, "TODO: Impl Debug for Interconnect")
     }
 }
+
+impl Default for Interconnect {
+    fn default() -> Interconnect {
+        // dummy impl to satisfy compiler
+        Interconnect::new(Vec::new())
+    }
+}


### PR DESCRIPTION
I was rewatching episode 3 and noticed you declined an offer to use Default for the uninitialised parts of the Cpu struct because you needed to dependency-inject the interconnect. I remembered there's a syntax for completing parts of a struct from something else, such as Default, and looking into getting it working.

Sorry for the slightly mangled formatting—I configured Vim to automatically use rustfmt, and while I was able to ditch most of the changes by not staging those hunks one trailing comma sneaked through, and rustfmt wanted the body of `Cpu::new` to be all on one line.
