### PR TITLE
Remove unnecessary `.wrapping_shl(2)` in favour of `<< 2`

### DIFF
--- a/src/cpu/cpu.rs
+++ b/src/cpu/cpu.rs
@@ -110,7 +110,7 @@ impl Cpu {
                     let old_pc = self.reg_pc;
 
                     let sign_extended_offset =
-                        instr.offset_sign_extended().wrapping_shl(2);
+                        instr.offset_sign_extended() << 2;
                     self.reg_pc =
                         self.reg_pc.wrapping_add(sign_extended_offset);
 


### PR DESCRIPTION
The wrapping behaviour of `wrapping_shl` refers to the right-hand side parameter, and not the left side. This means that `255u8.wrapping_shl(2)` is fully equivalent to both `255u8.wrapping_shl(10)` and `255u8 << 2` (where `255u8 << 10` would produce either an undefined value or panic).
