### PR TITLE
Slightly-less ambiguous panic messages

### DIFF
--- a/src/cpu/cp0/cp0.rs
+++ b/src/cpu/cp0/cp0.rs
@@ -12,7 +12,7 @@ impl Cp0 {
         match index {
             12 => { self.reg_status = (data as u32).into() },
             16 => { self.reg_config = (data as u32).into(); },
-            _ => panic!("Unrecognized Cp0 reg: {}, {:#x}", index, data)
+            _ => panic!("Unrecognized Cp0 reg: {}, {:#018x}", index, data)
         }
     }
 }

--- a/src/cpu/instruction.rs
+++ b/src/cpu/instruction.rs
@@ -10,8 +10,9 @@ pub struct Instruction(pub u32);
 impl Instruction {
     #[inline(always)]
     pub fn opcode(&self) -> Opcode {
-        Opcode::from_u32((self.0  >> 26) & 0b111111).unwrap_or_else(
-            || panic!("Unrecognized instruction: {:#x}", self.0))
+        let value = (self.0  >> 26) & 0b111111;
+        Opcode::from_u32(value).unwrap_or_else(
+            || panic!("Unrecognized instruction: {:#010x} (op: {:#08b})", self.0, value))
     }
 
     #[inline(always)]


### PR DESCRIPTION
I noticed you commonly had to pull out your calculator to find the opcode for an unknown instruction. This PR adds the bit-representation (including leading zeroes) to the panic message.

I also made the hex-prints I could find print with leading zeroes. Again, to remove ambiguity in debugging and make mistakes harder.

I hope you'll find this useful!
