### PR TITLE
Support SPECIAL instructions in Debug

### DIFF
--- a/src/cpu/instruction.rs
+++ b/src/cpu/instruction.rs
@@ -65,6 +65,9 @@ impl Instruction {
 
 impl fmt::Debug for Instruction {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self.opcode())
+        match self.opcode() {
+            Opcode::Special => write!(f, "{:?}", self.special_op()),
+            _ => write!(f, "{:?}", self.opcode())
+        }
     }
 }


### PR DESCRIPTION
Loving the stream so far. Just adding a quick change to show the instruction type of **SPECIAL** instructions in output, rather than just seeing "Special"
