### PR TITLE
Fix the implementation of MULTU

### DIFF
--- a/src/cpu/cpu.rs
+++ b/src/cpu/cpu.rs
@@ -116,7 +116,7 @@ impl Cpu {
                         let rs = self.read_reg_gpr(instr.rs()) as u32;
                         let rt = self.read_reg_gpr(instr.rt()) as u32;
 
-                        let res = ((rs * rt) as i32) as u64;
+                        let res = (rs as u64) * (rt as u64);
 
                         // TODO: Undefined if last 2 instructions were
                         //  MFHI or MFLO


### PR DESCRIPTION
I just watched the part of your stream where you implemented MULTU like this:

``` rust
let rs = self.read_reg_gpr(instr.rs()) as u32;
let rt = self.read_reg_gpr(instr.rt()) as u32;
let res = ((rs * rt) as i32) as u64;
self.reg_lo = (res as i32) as u64;
self.reg_hi = ((res >> 32) as i32) as u64;
```

This implementation looked bad to me because the top 32 bits of `res` will either be all zeros or all ones, so the value stored in `reg_hi` will also be all zeros or ones, which basically makes it useless.

I looked up the MULTU instruction in this [official-looking MIPS specification](http://www.cs.cmu.edu/afs/cs/academic/class/15740-f97/public/doc/mips-isa.pdf).  I'm not sure if this is the right document to look at, but it says:

> The 32-bit word value in GPR _rt_ is multiplied by the 32-bit value in GPR _rs_, treating
> both operands as unsigned values, **to produce a 64-bit result**. The low-order 32-bit
> word of the result is placed into special register _LO_, and the high-order 32-bit word is
> placed into special register _HI_.

The document has some pseudocode that makes it clear that the 32-bit values being stored in LO and HI should be signed extended.

I also looked at the [implementation of MULTU](https://github.com/project64/project64/blob/a76a174246053b5ac0484ddd05bcdfc9395d0220/Source/Project64-core/N64System/Interpreter/InterpreterOps.cpp#L1764) in Project 64.  They are storing useful data in HI (but they might be forgetting to sign extend the results).

So I think that the line that computes `res` should be changed to:

``` rust
let res = (rs as u64) * (rt as u64);
```

Cheers!

(Edit: [See this get merged in on the stream](https://www.twitch.tv/ferrisstreamsstuff/v/67806637?t=11m42s).)
