### PR TITLE
Update .gitignore to ignore editor artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target/
+*.rs~


### PR DESCRIPTION
This update tells git to ignore backup files, generated by emacs and vim while a file is being edited.
