### PR TITLE
Fix bug where delay slots didn't print, cleaned up

### DIFF
--- a/src/cpu/cpu.rs
+++ b/src/cpu/cpu.rs
@@ -108,8 +108,7 @@ impl Cpu {
                         // Update PC before executing delay slot instruction
                         self.reg_pc = self.read_reg_gpr(instr.rs());
 
-                        let delay_slot_instr = self.read_instruction(delay_slot_pc);
-                        self.execute_instruction(delay_slot_instr);
+                        self.execute_delay_slot(delay_slot_pc);
                     }
 
                     Multu => {
@@ -237,6 +236,15 @@ impl Cpu {
             }
         }
     }
+    
+    fn execute_delay_slot(&mut self, delay_slot_pc: u64) {
+        let delay_slot_instr = self.read_instruction(delay_slot_pc);
+        match delay_slot_instr.opcode() {
+            Special => { println!("reg_pc {:#018X} Special: {:?} (DELAY)", delay_slot_pc, delay_slot_instr.special_op()); }
+            _ => { println!("reg_pc {:#018X}: {:?} (DELAY)", delay_slot_pc, delay_slot_instr); }
+        }
+        self.execute_instruction(delay_slot_instr);
+    }
 
     fn branch<F>(&mut self, instr: Instruction, write_link: bool, f: F) -> bool where F: FnOnce(u64, u64) -> bool {
         let rs = self.read_reg_gpr(instr.rs());
@@ -257,8 +265,7 @@ impl Cpu {
             self.reg_pc =
                 self.reg_pc.wrapping_add(sign_extended_offset);
 
-            let delay_slot_instr = self.read_instruction(delay_slot_pc);
-            self.execute_instruction(delay_slot_instr);
+            self.execute_delay_slot(delay_slot_pc);
         }
 
         is_taken

--- a/src/cpu/cpu.rs
+++ b/src/cpu/cpu.rs
@@ -241,8 +241,8 @@ impl Cpu {
         let delay_slot_instr = self.read_instruction(delay_slot_pc);
         match delay_slot_instr.opcode() {
             Special => { println!("reg_pc {:#018X} Special: {:?} (DELAY)", delay_slot_pc, delay_slot_instr.special_op()); }
-            RegImm =>  { println!("reg_pc {:#018X}: RegImm: {:?} (DELAY)", self.reg_pc, instr.reg_imm_op()); }
-            _ => { println!("reg_pc {:#018X}: {:?} (DELAY)", delay_slot_pc, delay_slot_instr); }
+            RegImm =>  { println!("reg_pc {:#018X}: RegImm: {:?} (DELAY)", delay_slot_pc, delay_slot_instr.reg_imm_op()); }
+            _ => { println!("reg_pc {:#018X}: {:?} (DELAY)", delay_slot_pc, delay_slot_instr.opcode()); }
         }
         self.execute_instruction(delay_slot_instr);
     }

--- a/src/cpu/cpu.rs
+++ b/src/cpu/cpu.rs
@@ -241,6 +241,7 @@ impl Cpu {
         let delay_slot_instr = self.read_instruction(delay_slot_pc);
         match delay_slot_instr.opcode() {
             Special => { println!("reg_pc {:#018X} Special: {:?} (DELAY)", delay_slot_pc, delay_slot_instr.special_op()); }
+            RegImm =>  { println!("reg_pc {:#018X}: RegImm: {:?} (DELAY)", self.reg_pc, instr.reg_imm_op()); }
             _ => { println!("reg_pc {:#018X}: {:?} (DELAY)", delay_slot_pc, delay_slot_instr); }
         }
         self.execute_instruction(delay_slot_instr);

--- a/src/cpu/cpu.rs
+++ b/src/cpu/cpu.rs
@@ -242,7 +242,7 @@ impl Cpu {
         match delay_slot_instr.opcode() {
             Special => { println!("reg_pc {:#018X} Special: {:?} (DELAY)", delay_slot_pc, delay_slot_instr.special_op()); }
             RegImm =>  { println!("reg_pc {:#018X}: RegImm: {:?} (DELAY)", delay_slot_pc, delay_slot_instr.reg_imm_op()); }
-            _ => { println!("reg_pc {:#018X}: {:?} (DELAY)", delay_slot_pc, delay_slot_instr.opcode()); }
+            _ => { println!("reg_pc {:#018X}: {:?} (DELAY)", delay_slot_pc, delay_slot_instr); }
         }
         self.execute_instruction(delay_slot_instr);
     }


### PR DESCRIPTION
Delay slots weren't printing before, because the print statement was in run_instruction, while delay slots were run directly from branch. This commit adds a print statement before the delay slot is executed, and also indicates that a delay slot was executed.

Cleaned up version of #43
