### PR TITLE
Factored out instruction code, to make them more readable.

### DIFF
--- a/src/cpu/instruction.rs
+++ b/src/cpu/instruction.rs
@@ -16,13 +16,13 @@ impl Instruction {
     }
 
     #[inline(always)]
-    pub fn rs(&self) -> usize {
-        ((self.0 >> 21) & 0b11111) as usize
+    pub fn rs(&self) -> u32 {
+        ((self.0 >> 21) & 0b11111)
     }
 
     #[inline(always)]
-    pub fn rt(&self) -> usize {
-        ((self.0 >> 16) & 0b11111) as usize
+    pub fn rt(&self) -> u32 {
+        ((self.0 >> 16) & 0b11111)
     }
 
     #[inline(always)]
@@ -78,3 +78,4 @@ impl fmt::Debug for Instruction {
         }
     }
 }
+


### PR DESCRIPTION
The branch function was already written this way; the added run_rtype_instruction and run_itype_instruction functions now do the same.
They take a lambda for the execution of the opcode, allowing most opcodes to be written in one line. This also makes very clear what operaction each opcode is doing.

I've tried my best to avoid merge conflicts.
