### PR TITLE
Added support for Special opcodes when displaying opcode names.

### DIFF
--- a/src/cpu/cpu.rs
+++ b/src/cpu/cpu.rs
@@ -59,9 +59,10 @@ impl Cpu {
 
     pub fn run_instruction(&mut self) {
         let instr = self.read_instruction(self.reg_pc);
-
-        println!("reg_pc {:#018X}: {:?}", self.reg_pc, instr);
-
+        match instr.opcode() {
+            Special => { println!("reg_pc {:#018X}: Special: {:?}", self.reg_pc, instr.special_op()); }
+            _ =>       { println!("reg_pc {:#018X}: {:?}", self.reg_pc, instr); }
+        }
         self.reg_pc += 4;
         self.execute_instruction(instr);
     }

--- a/src/cpu/cpu.rs
+++ b/src/cpu/cpu.rs
@@ -61,6 +61,7 @@ impl Cpu {
         let instr = self.read_instruction(self.reg_pc);
         match instr.opcode() {
             Special => { println!("reg_pc {:#018X}: Special: {:?}", self.reg_pc, instr.special_op()); }
+            RegImm =>  { println!("reg_pc {:#018X}: RegImm: {:?}", self.reg_pc, instr.reg_imm_op()); }
             _ =>       { println!("reg_pc {:#018X}: {:?}", self.reg_pc, instr); }
         }
         self.reg_pc += 4;


### PR DESCRIPTION
Now special opcodes won't all just display "Special" on debug printout. They'll say "Special: <special_op>".

This applies the patch to the base code, and is independent of patch #44. That patch has a separate fix that's coming, as soon as I figure out how to update a pull request.
