### PR TITLE
Fixed addi overflow error.

### DIFF
--- a/src/cpu/cpu.rs
+++ b/src/cpu/cpu.rs
@@ -175,7 +175,7 @@ impl Cpu {
                         _ => {}
                     };
                     res
-                    }),
+                }),
             Addiu => self.imm_instr(instr, SignExtendResult::Yes, |rs, _, imm_sign_extended| rs.wrapping_add(imm_sign_extended)),
 
             Andi => self.imm_instr(instr, SignExtendResult::No, |rs, imm, _| rs & imm),

--- a/src/cpu/cpu.rs
+++ b/src/cpu/cpu.rs
@@ -159,9 +159,23 @@ impl Cpu {
 
             Addi =>
                 self.imm_instr(instr, SignExtendResult::Yes, |rs, _, imm_sign_extended| {
-                    // TODO: Handle overflow exception
-                    rs + imm_sign_extended
-                }),
+                    let rs_positive = (rs >> 31) & 1 == 0;
+                    let imm_positive = (imm_sign_extended >> 31) & 1 == 0;
+                    let res = rs.wrapping_add(imm_sign_extended);
+                    let res_positive = (res >> 31 & 1) == 0;
+                    match (rs_positive, imm_positive, res_positive) {
+                        (true, true, false)  => {
+                            panic!("Integer overflow exception not implemented! (p+p=n) {:016X} + {:016X} != {:016X}",
+                                res, imm_sign_extended, res);
+                        }
+                        (false, false, true) => {
+                            panic!("Integer overflow exception not implemented! (n+n=p) {:016X} + {:016X} != {:016X}",
+                                res, imm_sign_extended, res);
+                        }
+                        _ => {}
+                    };
+                    res
+                    }),
             Addiu => self.imm_instr(instr, SignExtendResult::Yes, |rs, _, imm_sign_extended| rs.wrapping_add(imm_sign_extended)),
 
             Andi => self.imm_instr(instr, SignExtendResult::No, |rs, imm, _| rs & imm),


### PR DESCRIPTION
The processor exception is still unhandled, but the rust types won't overflow anymore. I think it was because we were doing u64 addition, instead of i32? I don't know, so I just implemented it bit-wise, with a manual check for overflow.
