### PR TITLE
clear delay_slot_pc before executing the delay slot instruction

### DIFF
--- a/src/n64/cpu/cpu.rs
+++ b/src/n64/cpu/cpu.rs
@@ -75,9 +75,9 @@ impl Cpu {
     pub fn step(&mut self, interconnect: &mut Interconnect) {
         if let Some(pc) = self.delay_slot_pc {
             let instr = self.read_instruction(interconnect, pc);
-            self.execute_instruction(interconnect, instr);
-
             self.delay_slot_pc = None;
+
+            self.execute_instruction(interconnect, instr);
         } else {
             let instr = self.read_instruction(interconnect, self.reg_pc);
 


### PR DESCRIPTION
In theory a delay slot instruction itself could add a new delay slot
instruction.  If this were to occur the new delay slot instruction would
be lost with the current code.
