### PR TITLE
Use rustyline as a line editor for the debugger.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,17 +5,14 @@ dependencies = [
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_primitive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "num 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustyline 0.2.3 (git+https://github.com/kkawakam/rustyline)",
 ]
 
 [[package]]
-name = "advapi32-sys"
-version = "0.1.2"
+name = "bitflags"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "byteorder"
@@ -23,17 +20,40 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "encode_unicode"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "enum_primitive"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.6"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "nix"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "nom"
@@ -42,31 +62,104 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "num"
-version = "0.1.30"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-bigint 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-complex 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-iter 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-rational 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "rand"
-version = "0.3.13"
+name = "num-bigint"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "advapi32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-bigint 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rand"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-serialize"
-version = "0.3.16"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rustyline"
+version = "0.2.3"
+source = "git+https://github.com/kkawakam/rustyline#f22d3c275177e4378e8c634bf000d0660c8dcfe0"
+dependencies = [
+ "encode_unicode 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi"
-version = "0.2.5"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ byteorder = "0.4.2"
 num = "0.1.30"
 enum_primitive = "0.1.0"
 nom = "^1.2.3"
+rustyline = { git = "https://github.com/kkawakam/rustyline" }

--- a/src/debugger/mod.rs
+++ b/src/debugger/mod.rs
@@ -1,8 +1,10 @@
 mod command;
 
-use std::io::{stdin, stdout};
-use std::io::prelude::*;
-use std::borrow::Cow;
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use std::process;
+use rustyline::Editor;
 use n64::cpu::Instruction;
 use n64::cpu::opcode::Opcode::*;
 use n64::mem_map;
@@ -10,41 +12,64 @@ use n64::mem_map::Addr::*;
 use n64::N64;
 use self::command::Command;
 
-pub struct Debugger {
-    n64: N64,
+static HISTFILE: &'static str = ".config/rustendo64/debug_history";
 
+pub struct Debugger<'e> {
+    n64: N64,
+    editor: Editor<'e>,
+    history_path: Option<PathBuf>,
     last_command: Option<Command>,
 }
 
-impl Debugger {
-    pub fn new(n64: N64) -> Debugger {
+impl<'e> Debugger<'e> {
+    pub fn new(n64: N64) -> Debugger<'e> {
+        let mut editor = Editor::new();
+        let history_path = env::home_dir().map(|p| p.join(HISTFILE));
+        if let Some(ref path) = history_path {
+            let _ = editor.load_history(path);
+        }
         Debugger {
             n64: n64,
-
+            editor: editor,
+            history_path: history_path,
             last_command: None,
         }
     }
 
     pub fn run(&mut self) {
         loop {
-            print!("r64> ");
-            stdout().flush().unwrap();
+            match self.editor.readline("r64> ") {
+                Err(_) => {
+                    println!("Interrupt/Quit.");
+                    process::exit(1);
+                }
+                Ok(input) => {
+                    if input.len() > 0 {
+                        self.editor.add_history_entry(&input);
+                    }
 
-            let command = match (read_stdin().parse(), self.last_command) {
-                (Ok(Command::Repeat), Some(c)) => Ok(c),
-                (Ok(Command::Repeat), None) => Err("No last command".into()),
-                (Ok(c), _) => Ok(c),
-                (Err(e), _) => Err(e),
-            };
+                    let command = match (input.parse(), self.last_command) {
+                        (Ok(Command::Repeat), Some(c)) => Ok(c),
+                        (Ok(Command::Repeat), None) => Err("No last command".into()),
+                        (Ok(c), _) => Ok(c),
+                        (Err(e), _) => Err(e)
+                    };
 
-            match command {
-                Ok(Command::Step(count)) => self.step(count),
-                Ok(Command::Exit) => break,
-                Ok(Command::Repeat) => unreachable!(),
-                Err(ref e) => println!("{}", e),
+                    match command {
+                        Ok(Command::Step(count)) => self.step(count),
+                        Ok(Command::Exit) => {
+                            if let Some(ref path) = self.history_path {
+                                let _ = fs::create_dir_all(path.parent().unwrap());
+                                let _ = self.editor.save_history(path);
+                            }
+                            break;
+                        }
+                        Ok(Command::Repeat) => unreachable!(),
+                        Err(ref e) => println!("{}", e)
+                    }
+                    self.last_command = command.ok();
+                }
             }
-
-            self.last_command = command.ok();
         }
     }
 
@@ -74,10 +99,4 @@ impl Debugger {
             self.n64.step();
         }
     }
-}
-
-fn read_stdin() -> String {
-    let mut input = String::new();
-    stdin().read_line(&mut input).unwrap();
-    input.trim().into()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 #![deny(trivial_casts, trivial_numeric_casts)]
 
 extern crate byteorder;
-
+extern crate rustyline;
 extern crate num;
 
 #[macro_use]


### PR DESCRIPTION
Needed a "cargo update" since the currently selected version of num needs a libc version that rustyline doesn't want to work with.

Notes:
- No completion yet.
- Making all errors while loading/saving the history file silent was intentional, if it's your preference to print warnings that can be changed of course.
- Both Ctrl-C and Ctrl-D will exit, I found that helpful since rapid start-break-edit code-restart cycles are common. Later it can be changed to match the gdb behavior of just giving a new prompt on interrupt.
- The history file path is hardcoded to the XDG standard directory, I'll leave it to some Windows/Mac experts to find the right crate to make this do the right thing on these OS.
